### PR TITLE
Fix in description

### DIFF
--- a/xml/ConditionType.xml
+++ b/xml/ConditionType.xml
@@ -1,6 +1,6 @@
 <codelist name="ConditionType"   xml:lang="en">
     <metadata>
-        <description>Type of Contact</description>
+        <description>Condition type – e.g. policy, performance.</description>
     </metadata>
     <codelist-items>
         <codelist-item>


### PR DESCRIPTION
Replaced with the text of the "definition" in the standard (https://docs.google.com/spreadsheet/ccc?key=0AnWngmdQt3stdFJiX2FFS2VnVHc4ZkFFV2JObEV3Z2c#gid=1)
