### PR TITLE
Renames the name to Geographic Exacness

### DIFF
--- a/xml/GeographicExactness.xml
+++ b/xml/GeographicExactness.xml
@@ -1,6 +1,6 @@
 <codelist name="GeographicExactness" xml:lang="en" complete="1">
     <metadata>
-        <name>Geographic Supporting Information</name>
+        <name>Geographic Exactness</name>
         <description></description>
     </metadata>
     <codelist-items>


### PR DESCRIPTION
This codelist was renamed at the last minute before the 1.04 release - the <name> element was missed out of the change by accident. Fixed.
