### PR TITLE
[#90] v1.05 Combine two codelist-items with the same code

### DIFF
--- a/xml/BudgetIdentifier.xml
+++ b/xml/BudgetIdentifier.xml
@@ -136,12 +136,7 @@
         </codelist-item>
         <codelist-item>
             <code>2.1.2</code>
-            <name>Justice, Law and Order - police</name>
-            <category>2.1</category>
-        </codelist-item>
-        <codelist-item>
-            <code>2.1.2</code>
-            <name>Justice, Law and Order - fire</name>
+            <name>Justice, Law and Order - fire or police</name>
             <category>2.1</category>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
The code must be unique within a Codelist. As such, having multiple codelist-items with the same Code is incorrect.

This combines the two into a single value with a combined description.

Fixes #90 