### PR TITLE
Remove reference to the BudgetIdentifier codelist in the definition of country-budget-items/budget-item/@code (v2.03 upgrade)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,12 +55,12 @@ It's structured as a list of `mapping` elements, which each have a `path` elemen
 
     <mappings>
         <mapping>
-            <path>//iati-activity/@default-currency</path>
-            <codelist ref="Currency" />
+            <path>//iati-activity/transaction/recipient-country/@code</path>
+            <codelist ref="Country" />
         </mapping>
         <mapping>
-            <path>//iati-activity/country-budget-items/budget-item/@code</path>
-            <codelist ref="BudgetIdentifier" />
+            <path>//iati-activity/transaction/recipient-region/@code</path>
+            <codelist ref="Region" />
             <condition>@vocabulary = '1'</condition>
         </mapping>
         ...

--- a/mapping.xml
+++ b/mapping.xml
@@ -52,11 +52,6 @@
         <codelist ref="BudgetIdentifierVocabulary" />
     </mapping>
     <mapping>
-        <path>//iati-activity/country-budget-items/budget-item/@code</path>
-        <codelist ref="BudgetIdentifier" />
-        <condition>@vocabulary = '1'</condition>
-    </mapping>
-    <mapping>
         <path>//iati-activity/country-budget-items/budget-item/description/@type</path>
         <codelist ref="DescriptionType" />
     </mapping>


### PR DESCRIPTION
Fixes #138.

This relates to IATI/IATI-Codelists-NonEmbedded#242.

This also updates the README to replace an old BudgetIdentifier example.