### PR TITLE
gitignore mapping.json (v1.05)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ combined-xml
 *.swp
 *.pyc
 *~
+mapping.json


### PR DESCRIPTION
This file is generated as part of the docs generation process. It should
be gitignored.