### PR TITLE
After copying, remove generated mapping.json (v1.04)

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -26,4 +26,5 @@ python old.py
 python mappings_to_json.py
 cp mapping.{xml,json} out/clv1/
 cp mapping.{xml,json} out/clv2/
+rm mapping.json
 


### PR DESCRIPTION
The leftover file is just cruft, and should be removed.