### PR TITLE
Allow custom namespace use on `codelist-item`s (v2.03)

### DIFF
--- a/codelist.xsd
+++ b/codelist.xsd
@@ -49,11 +49,13 @@
       <xs:element name="description" type="textType" minOccurs="0" maxOccurs="1" />
       <xs:element name="category" type="xs:string" minOccurs="0" maxOccurs="1" />
       <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="public-database" use="optional"/>
     <xs:attribute name="status" type="xs:string" use="optional"/>
     <xs:attribute name="activation-date" type="xs:date" use="optional"/>
     <xs:attribute name="withdrawal-date" type="xs:date" use="optional"/>
+    <xs:anyAttribute processContents="lax" namespace="##other"/>
   </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
Refs IATI/IATI-Codelists-NonEmbedded#253.

Currently, custom namespace elements / attributes can only be used in weird places. They’re probably of most use on the `codelist-item` element. This PR adds them there.