### PR TITLE
Swap descriptions for activity status 3 & 4 (v2.02)

### DIFF
--- a/xml/ActivityStatus.xml
+++ b/xml/ActivityStatus.xml
@@ -35,7 +35,7 @@
                 <narrative xml:lang="fr">Finalisation</narrative>
             </name>
             <description>
-                <narrative>Physical activity is complete or the final disbursement has been made.</narrative>
+                <narrative>Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&amp;E</narrative>
             </description>
         </codelist-item>
         <codelist-item>
@@ -45,7 +45,7 @@
                 <narrative xml:lang="fr">Fermé</narrative>
             </name>
             <description>
-                <narrative>Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&amp;E</narrative>
+                <narrative>Physical activity is complete or the final disbursement has been made.</narrative>
             </description>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
This is a bugfix for v2.0x, as discussed here:
https://discuss.iatistandard.org/t/activitystatus-codes-mixup-of-descriptions-for-codes-3-4/304

Refs #172.