### PR TITLE
Bugfix: Switch descriptions for activity status codes 3 & 4; clarify names (v2.02)

### DIFF
--- a/xml/ActivityStatus.xml
+++ b/xml/ActivityStatus.xml
@@ -31,7 +31,7 @@
         <codelist-item>
             <code>3</code>
             <name>
-                <narrative>Completion</narrative>
+                <narrative>Finalisation</narrative>
                 <narrative xml:lang="fr">Finalisation</narrative>
             </name>
             <description>
@@ -41,7 +41,7 @@
         <codelist-item>
             <code>4</code>
             <name>
-                <narrative>Post-completion</narrative>
+                <narrative>Closed</narrative>
                 <narrative xml:lang="fr">Fermé</narrative>
             </name>
             <description>

--- a/xml/ActivityStatus.xml
+++ b/xml/ActivityStatus.xml
@@ -35,7 +35,7 @@
                 <narrative xml:lang="fr">Finalisation</narrative>
             </name>
             <description>
-                <narrative>Physical activity is complete or the final disbursement has been made.</narrative>
+                <narrative>Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&amp;E</narrative>
             </description>
         </codelist-item>
         <codelist-item>
@@ -45,7 +45,7 @@
                 <narrative xml:lang="fr">Fermé</narrative>
             </name>
             <description>
-                <narrative>Physical activity is complete or the final disbursement has been made, but the activity remains open pending financial sign off or M&amp;E</narrative>
+                <narrative>Physical activity is complete or the final disbursement has been made.</narrative>
             </description>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
As agreed in this IATI discuss post:
https://discuss.iatistandard.org/t/activitystatus-codes-mixup-of-descriptions-for-codes-3-4/304/65

Refs #172.

A summary of the changes to the codelist is shown in the following table:

**Activity Status Codelist (updated)**

| Code | Name (en) | Name (fr) | Description (en) |
|--------|---|----------|----|
| 1 | Pipeline/identification | Planification | The activity is being scoped or planned |
| 2 | Implementation | Actif | The activity is currently being implemented |
| 3 | ~~Completion~~   **Finalisation** | Finalisation | Physical activity is complete or the final disbursement has been made, **but the activity remains open pending financial sign off or M&amp;E**. |
| 4 | ~~Post-completion~~   **Closed** | Fermé | Physical activity is complete or the final disbursement has been made ~~, but the activity remains open pending financial sign off or M&amp;E~~. |
| 5 | Cancelled | Annulé | The activity has been cancelled |
| 6 | Suspended | Suspendu | The activity has been temporarily suspended |
