### PR TITLE
Allow recipient-region/@vocabulary to be omitted (v2.02)

### DIFF
--- a/mapping.xml
+++ b/mapping.xml
@@ -263,7 +263,7 @@
     <mapping>
         <path>//iati-activity/transaction/recipient-region/@code</path>
         <codelist ref="Region" />
-        <condition>@vocabulary = '1'</condition>
+        <condition>@vocabulary = '1' or not(@vocabulary)</condition>
     </mapping>
     <mapping>
         <path>//iati-activity/transaction/recipient-region/@vocabulary</path>


### PR DESCRIPTION
Default region code list is the same as `@vocabulary='1'`