### PR TITLE
Output v1.0x codelists as CLv3 (v1.05)

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -17,13 +17,21 @@ done
 
 rm -rf out
 mkdir out
-mkdir out/clv2
+mkdir -p out/clv2 out/clv3/xml
 cp -r combined-xml out/clv2/xml
+
+for f in combined-xml/*; do
+    python v2tov3.py $f > out/clv3/xml/`basename $f`;
+done
+
 
 python gen.py
 python old.py
 
+cp -r out/clv2/{codelists.json,codelists.xml,csv,json} out/clv3/
+
 python mappings_to_json.py
 cp mapping.{xml,json} out/clv1/
 cp mapping.{xml,json} out/clv2/
+cp mapping.{xml,json} out/clv3/
 

--- a/gen.sh
+++ b/gen.sh
@@ -26,7 +26,7 @@ done
 
 
 python gen.py
-python old.py
+python v2tov1.py
 
 cp -r out/clv2/{codelists.json,codelists.xml,csv,json} out/clv3/
 

--- a/v2tov1.py
+++ b/v2tov1.py
@@ -24,8 +24,8 @@ def utf8_encode_dict(d):
 old_codelist_index = E.codelists()
 old_codelist_index_json_list = []
 
-for fname in os.listdir('combined-xml'):
-    codelist = ET.parse(os.path.join('combined-xml',fname))
+for fname in os.listdir(os.path.join('out','clv2','xml')):
+    codelist = ET.parse(os.path.join('out','clv2','xml',fname))
     attrib = codelist.getroot().attrib
 
 
@@ -84,7 +84,7 @@ for fname in os.listdir('combined-xml'):
             old_codelist_json_item['category'] = category.text
 
             try:
-                category_item = ET.parse(os.path.join('combined-xml',attrib['category-codelist']+'.xml')).xpath('//codelist-item[code="{0}"]'.format(category.text))[0]
+                category_item = ET.parse(os.path.join('out','clv2','xml',attrib['category-codelist']+'.xml')).xpath('//codelist-item[code="{0}"]'.format(category.text))[0]
                 category_name = category_item.xpath('name[not(xml:lang) or xml:lang="en"]')[0].text
             except (IndexError, KeyError):
                 category_item = None

--- a/v2tov3.py
+++ b/v2tov3.py
@@ -10,6 +10,7 @@ Example usage:
 
 """
 
+
 def update_to_narrative(parent, element_name):
     elements = parent.findall(element_name)
     if elements:
@@ -19,6 +20,7 @@ def update_to_narrative(parent, element_name):
             parent.remove(element)
             element.tag = 'narrative'
             new_element.append(element)
+
 
 parser = ET.XMLParser(remove_blank_text=True)
 tree = ET.parse(sys.argv[1], parser)
@@ -39,22 +41,22 @@ for codelist_item in tree.find('codelist-items').findall('codelist-item'):
     codelist_item[:] = sum((codelist_item.findall(x) for x in ['code', 'name', 'description', 'category', 'url']), [])
 
 
-
 # Adapted from code at http://effbot.org/zone/element-lib.htm
 def indent(elem, level=0, shift=2):
-    i = "\n" + level*" "*shift
+    i = "\n" + level * " " * shift
     if len(elem):
         if not elem.text or not elem.text.strip():
-            elem.text = i + " "*shift
+            elem.text = i + " " * shift
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for elem in elem:
-            indent(elem, level+1, shift)
+            indent(elem, level + 1, shift)
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
     else:
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
+
 
 indent(tree.getroot(), 0, 4)
 

--- a/v2tov3.py
+++ b/v2tov3.py
@@ -60,4 +60,4 @@ def indent(elem, level=0, shift=2):
 
 indent(tree.getroot(), 0, 4)
 
-tree.write(sys.stdout, encoding='utf-8')
+tree.write(sys.stdout.buffer, encoding='utf-8')

--- a/v2tov3.py
+++ b/v2tov3.py
@@ -1,0 +1,61 @@
+from lxml import etree as ET
+import sys
+
+"""
+
+Example usage:
+    cp -r xml xml.old
+    cd xml.old
+    for f in *; do python ../v2tov3.py $f > ../xml/$f; done
+
+"""
+
+def update_to_narrative(parent, element_name):
+    elements = parent.findall(element_name)
+    if elements:
+        new_element = ET.Element(element_name)
+        parent.append(new_element)
+        for element in elements:
+            parent.remove(element)
+            element.tag = 'narrative'
+            new_element.append(element)
+
+parser = ET.XMLParser(remove_blank_text=True)
+tree = ET.parse(sys.argv[1], parser)
+
+metadata = tree.find('metadata')
+update_to_narrative(metadata, 'name')
+update_to_narrative(metadata, 'description')
+# Ensure that url is the last element
+url = metadata.find('url')
+if url is not None:
+    metadata.remove(url)
+    metadata.append(url)
+
+for codelist_item in tree.find('codelist-items').findall('codelist-item'):
+    update_to_narrative(codelist_item, 'name')
+    update_to_narrative(codelist_item, 'description')
+
+    codelist_item[:] = sum((codelist_item.findall(x) for x in ['code', 'name', 'description', 'category', 'url']), [])
+
+
+
+# Adapted from code at http://effbot.org/zone/element-lib.htm
+def indent(elem, level=0, shift=2):
+    i = "\n" + level*" "*shift
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + " "*shift
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1, shift)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
+indent(tree.getroot(), 0, 4)
+
+tree.write(sys.stdout, encoding='utf-8')


### PR DESCRIPTION
Refs #153.

The v2tov3.py file [comes from here](https://github.com/IATI/IATI-Codelists/blob/version-2.03/v2tov3.py), so actually there’s very little new code in this PR.