### PR TITLE
Add python 2 support (v2.03)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -4,6 +4,7 @@ import re
 import csv
 import json
 from functools import partial
+import sys
 
 languages = ['en', 'fr']
 
@@ -28,13 +29,13 @@ def codelist_item_todict(codelist_item, default_lang='', lang='en'):
     return out
 
 
-# def utf8_encode_dict(d):
-#     def enc(a):
-#         if type(a) == str:
-#             return a.encode('utf8')
-#         else:
-#             return None
-#     return dict((enc(k), enc(v)) for k, v in d.items())
+def utf8_encode_dict(d):
+    def enc(a):
+        if type(a) == str:
+            return a.encode('utf8')
+        else:
+            return None
+    return dict((enc(k), enc(v)) for k, v in d.items())
 
 
 for language in languages:
@@ -70,6 +71,8 @@ for language in languages:
         dw = csv.DictWriter(open(os.path.join(OUTPUTDIR, 'csv', language, attrib['name'] + '.csv'), 'w'), fieldnames)
         dw.writeheader()
         for row in codelist_dicts:
+            if sys.version_info.major == 2:
+                row = utf8_encode_dict(row)
             dw.writerow(row)
 
         name_elements = codelist.getroot().xpath('/codelist/metadata/name[{}@xml:lang="{}"]'.format('not(@xml:lang) or ' if language == default_lang else '', language))

--- a/v2tov1.py
+++ b/v2tov1.py
@@ -4,6 +4,7 @@ import datetime
 import pytz
 import json
 import csv
+import sys
 from lxml import etree as ET
 from lxml.builder import E
 from collections import OrderedDict
@@ -18,13 +19,13 @@ except OSError:
     pass
 
 
-# def utf8_encode_dict(d):
-#     def enc(a):
-#         if a is None:
-#             return None
-#         else:
-#             return a.encode('utf8')
-#     return dict((enc(k), enc(v)) for k, v in d.items())
+def utf8_encode_dict(d):
+    def enc(a):
+        if a is None:
+            return None
+        else:
+            return a.encode('utf8')
+    return dict((enc(k), enc(v)) for k, v in d.items())
 
 
 old_codelist_index = E.codelists()
@@ -114,6 +115,8 @@ for fname in os.listdir(os.path.join('out', 'clv2', 'xml')):
         dictwriter = csv.DictWriter(fp, ['code', 'name', 'description', 'language', 'category', 'category-name', 'category-description'])
         dictwriter.writeheader()
         for line in old_codelist_json_list:
+            if sys.version_info.major == 2:
+                line = utf8_encode_dict(line)
             dictwriter.writerow(line)
 
     ET.ElementTree(old_codelist).write(os.path.join(OUTPUTDIR, 'codelist', fname), pretty_print=True)

--- a/v2tov3.py
+++ b/v2tov3.py
@@ -61,4 +61,4 @@ def indent(elem, level=0, shift=2):
 
 indent(tree.getroot(), 0, 4)
 
-tree.write(sys.stdout, encoding='utf-8')
+print(ET.tostring(tree).decode())

--- a/v3tov2.py
+++ b/v3tov2.py
@@ -43,4 +43,4 @@ def indent(elem, level=0, shift=2):
 
 indent(tree.getroot(), 0, 4)
 
-tree.write(sys.stdout.buffer)
+print(ET.tostring(tree).decode())


### PR DESCRIPTION
This repo was recently upgraded to support python3, which is **awesome**. Python2 support was removed, which would be fine except that the IATI-Dashboard currently relies on it (see IATI/IATI-Dashboard#546).

Since it’s a pretty big task to upgrade the IATI Dashboard to python3, but a small task to add python2.7 support to this repo, this PR does the latter.