### PR TITLE
Remove codelist mapping for description/@type attributes removed sinc…

### DIFF
--- a/mapping.xml
+++ b/mapping.xml
@@ -57,10 +57,6 @@
         <condition>../@vocabulary = '1'</condition>
     </mapping>
     <mapping>
-        <path>//iati-activity/country-budget-items/budget-item/description/@type</path>
-        <codelist ref="DescriptionType" />
-    </mapping>
-    <mapping>
         <path>//iati-activity/crs-add/channel-code/text()</path>
         <codelist ref="CRSChannelCode" />
     </mapping>
@@ -239,10 +235,6 @@
         <codelist ref="ResultType" />
     </mapping>
     <mapping>
-        <path>//iati-activity/result/description/@type</path>
-        <codelist ref="DescriptionType" />
-    </mapping>
-    <mapping>
         <path>//iati-activity/result/document-link/@format</path>
         <codelist ref="FileFormat" />
     </mapping>
@@ -269,10 +261,6 @@
     <mapping>
         <path>//iati-activity/result/indicator/baseline/document-link/language/@code</path>
         <codelist ref="Language" />
-    </mapping>
-    <mapping>
-        <path>//iati-activity/result/indicator/description/@type</path>
-        <codelist ref="DescriptionType" />
     </mapping>
     <mapping>
         <path>//iati-activity/result/indicator/document-link/@format</path>


### PR DESCRIPTION
…e 2.01

Description Type
[added 08-09-2014 - this is a bug fix]

All description types currently contain a type attribute. This is only applicable to iati-activity/description
Delete the following attributes
country-budget-items/budget-item/description/@type
result/description/@type
result/indicator/description/@type
 For technical details about implementing this proposal go to: https://github.com/IATI/IATI-Schemas/issues/163
 
 Via: https://support.iatistandard.org/hc/en-us/articles/214393546-Version-2-01-Iteration-3-8-Miscellaneous