### PR TITLE
Remove codelist mapping for description/@type attributes removed sinc…

### DIFF
--- a/mapping.xml
+++ b/mapping.xml
@@ -53,10 +53,6 @@
         <condition>../@vocabulary = '1'</condition>
     </mapping>
     <mapping>
-        <path>//iati-activity/country-budget-items/budget-item/description/@type</path>
-        <codelist ref="DescriptionType" />
-    </mapping>
-    <mapping>
         <path>//iati-activity/crs-add/channel-code/text()</path>
         <codelist ref="CRSChannelCode" />
     </mapping>
@@ -216,16 +212,8 @@
         <codelist ref="ResultType" />
     </mapping>
     <mapping>
-        <path>//iati-activity/result/description/@type</path>
-        <codelist ref="DescriptionType" />
-    </mapping>
-    <mapping>
         <path>//iati-activity/result/indicator/@measure</path>
         <codelist ref="IndicatorMeasure" />
-    </mapping>
-    <mapping>
-        <path>//iati-activity/result/indicator/description/@type</path>
-        <codelist ref="DescriptionType" />
     </mapping>
     <mapping>
         <path>//iati-activity/result/indicator/reference/@vocabulary</path>


### PR DESCRIPTION
…e 2.01

Description Type
[added 08-09-2014 - this is a bug fix]

All description types currently contain a type attribute. This is only applicable to iati-activity/description
Delete the following attributes
country-budget-items/budget-item/description/@type
result/description/@type
result/indicator/description/@type
 For technical details about implementing this proposal go to: https://github.com/IATI/IATI-Schemas/issues/163
 
 Via: https://support.iatistandard.org/hc/en-us/articles/214393546-Version-2-01-Iteration-3-8-Miscellaneous