### PR TITLE
remove trigger of validator-rule-tracker 2.03

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,27 +70,6 @@ jobs:
             exit 1
           fi
 
-  update-rule-tracker:
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }} # only push to the rule tracker on PUSH
-    steps:
-      - name: 'Trigger update of rule tracker repo .csv'
-        run: |
-          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -H 'Authorization: Bearer ${{ secrets.IATI_BOT_PAT }}' \
-          -X POST https://api.github.com/repos/IATI/validator-rule-tracker/dispatches \
-          --data '{"event_type": "update", "client_payload": { "resourceName": "codelists", "repo": "'"$GITHUB_REPOSITORY"'", "sha": "'"$GITHUB_SHA"'"}}' \
-          --output curl_out.txt \
-          --silent )
-          echo $HTTP_CODE
-          if [[ $HTTP_CODE != '204' ]] ; then
-            echo "Reponse is not 204, check error logs"
-            cat curl_out.txt
-            exit 1
-          fi
-
   automerge:
     needs: build
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ This tool supports Python 3.x. To use this script, we recommend the use of a vir
 Automated Downstream Updates
 ============================
 
-The GitHub workflow ``.github/workflows/CI.yml``, triggers a workflows in a repository related to the IATI Validator that utilises the IATI codelists. 
+The GitHub workflow ``.github/workflows/CI.yml``, triggers a workflow in a repository related to the IATI Validator that utilises the IATI codelists. 
 
 - `IATI/IATI-Validator-Codelists <https://github.com/IATI/IATI-Validator-Codelists>`__
 

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,7 @@ This tool supports Python 3.x. To use this script, we recommend the use of a vir
 Automated Downstream Updates
 ============================
 
-The GitHub workflow ``.github/workflows/CI.yml``, triggers workflows in 2 repositories related to the IATI Validator that utilise the IATI codelists. 
+The GitHub workflow ``.github/workflows/CI.yml``, triggers a workflows in a repository related to the IATI Validator that utilises the IATI codelists. 
 
 - `IATI/IATI-Validator-Codelists <https://github.com/IATI/IATI-Validator-Codelists>`__
-- `IATI/validator-rule-tracker <https://github.com/IATI/validator-rule-tracker>`__
 


### PR DESCRIPTION
[Trello](https://trello.com/c/tYdinKiA)
Now triggered in IATI-Validator-Codelists repo: https://github.com/IATI/IATI-Validator-Codelists/pull/14