### PR TITLE
Ignore unrecognised codelist xml in gen.py

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -68,7 +68,7 @@ for language in languages:
         if fname == 'OrganisationRegistrationAgency.xml':
             fieldnames.append('public-database')
 
-        dw = csv.DictWriter(open(os.path.join(OUTPUTDIR, 'csv', language, attrib['name'] + '.csv'), 'w'), fieldnames)
+        dw = csv.DictWriter(open(os.path.join(OUTPUTDIR, 'csv', language, attrib['name'] + '.csv'), 'w'), fieldnames, extrasaction='ignore')
         dw.writeheader()
         for row in codelist_dicts:
             if sys.version_info.major == 2:


### PR DESCRIPTION
This is required to merge https://github.com/IATI/IATI-Codelists-NonEmbedded/pull/427 which adds 2 extra namespaced fields (`crs` and `tossd`).

We will need to do this for each version of the standard that we build.